### PR TITLE
preflight script added & PR template modified to include a check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,5 +7,5 @@ BLACK_FLASH_ATTEMPT
 
 ## What changed
 
-## How to test
-- [ ] `dotnet test`
+## Preflight
+- [ ] I ran `.\scripts\preflight.ps1`

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = "Stop"
+
+Write-Host ""
+Write-Host "========================================"
+Write-Host "[SURE-HIT] PREFLIGHT START"
+Write-Host "dotnet restore / build / test (Release)"
+Write-Host "========================================"
+Write-Host ""
+
+dotnet restore
+dotnet build --configuration Release --no-restore
+dotnet test  --configuration Release --no-build
+
+Write-Host ""
+Write-Host "========================================"
+Write-Host "[SURE-HIT] PREFLIGHT PASS"
+Write-Host "========================================"
+Write-Host ""


### PR DESCRIPTION
<!--
Optional marker for a first-contact CI run.
Include this only if you are intentionally attempting a Black Flash.

BLACK_FLASH_ATTEMPT
-->

## What changed
Preflight script has been added

## Preflight
- [x] I ran `.\scripts\preflight.ps1`