### PR TITLE
Added SVG references to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ UI and distribution layers will be added later.
 ```
 or run the .exe directly for interactive mode.
 
-How to run examples:
+Copy/paste example:
 
 ```
 .\rapid.exe estimate --project .\examples\exampleproject.json --format text
@@ -92,5 +92,5 @@ Notes:
 Generate a scaled wall strip diagram (no room topology):
 
 ```bash
-rapid estimate --project examples/project.basic.json --format svg --out walls.svg
+rapid estimate --project examples/exampleproject2.json --format svg --out walls.svg
 ```

--- a/src/RapidTakeoff.Cli/Program.cs
+++ b/src/RapidTakeoff.Cli/Program.cs
@@ -113,12 +113,15 @@ public static class Program
         Console.WriteLine();
 
         Console.WriteLine("Usage (estimate):");
-        Console.WriteLine("  rapid estimate --project .\\examples\\project.json --format text");
+        Console.WriteLine("  rapid estimate --project .\\examples\\exampleproject.json --format text");
+        Console.WriteLine("  rapid estimate --project .\\examples\\exampleproject.json --format csv");
+        Console.WriteLine("  rapid estimate --project .\\examples\\exampleproject2.json --format svg --out .\\out\\estimate.svg");
         Console.WriteLine();
         Console.WriteLine("Options (estimate):");
         Console.WriteLine("  --project <path>             Path to project JSON file (required)");
         Console.WriteLine("  --format <text|csv|svg>      Output format (default: text)");
         Console.WriteLine("  --out <path>                 Required when --format svg (output .svg path)");
+        Console.WriteLine("                               SVG writes a wall-strip diagram to the --out file");
         Console.WriteLine();
     }
 
@@ -542,7 +545,7 @@ public static class Program
             return false;
 
         Console.WriteLine();
-        Console.WriteLine("Enter a command and options (example: estimate --project .\\examples\\project1.json).");
+        Console.WriteLine("Enter a command and options (example: estimate --project .\\examples\\exampleproject.json).");
         Console.WriteLine("Press Enter on an empty line to exit.");
         Console.WriteLine();
 


### PR DESCRIPTION
<!--
Optional marker for a first-contact CI run.
Include this only if you are intentionally attempting a Black Flash.

BLACK_FLASH_ATTEMPT
-->

## What changed
Added references to svg generation in the documentation

## Preflight
- [x] I ran `.\scripts\preflight.ps1`