### PR TITLE
Created length as a unit primitive.

### DIFF
--- a/src/RapidTakeoff.Core/units/Length.cs
+++ b/src/RapidTakeoff.Core/units/Length.cs
@@ -7,6 +7,10 @@ namespace RapidTakeoff.Core.Units;
 /// </summary>
 public readonly record struct Length
 {
+    private const int ArchitecturalDenominator = 16;
+    private const int InchesPerFoot = 12;
+    private const double MillimetersPerInch = 25.4;
+
     /// <summary>
     /// Gets the total length in inches.
     /// </summary>
@@ -15,16 +19,11 @@ public readonly record struct Length
     /// <summary>
     /// Gets the total length in feet.
     /// </summary>
-    public double TotalFeet => TotalInches / 12.0;
+    public double TotalFeet => TotalInches / InchesPerFoot;
 
     private Length(double totalInches)
     {
-        if (double.IsNaN(totalInches) || double.IsInfinity(totalInches))
-            throw new ArgumentOutOfRangeException(nameof(totalInches), "Length must be a finite number.");
-
-        if (totalInches < 0)
-            throw new ArgumentOutOfRangeException(nameof(totalInches), "Length cannot be negative.");
-
+        ValidateFiniteNonNegative(totalInches, nameof(totalInches), "Length");
         TotalInches = totalInches;
     }
 
@@ -32,13 +31,21 @@ public readonly record struct Length
     /// Creates a <see cref="Length"/> from inches.
     /// </summary>
     /// <param name="inches">Total inches (must be finite and non-negative).</param>
-    public static Length FromInches(double inches) => new(inches);
+    public static Length FromInches(double inches)
+    {
+        ValidateFiniteNonNegative(inches, nameof(inches), "Inches");
+        return new(inches);
+    }
 
     /// <summary>
     /// Creates a <see cref="Length"/> from feet.
     /// </summary>
     /// <param name="feet">Total feet (must be finite and non-negative).</param>
-    public static Length FromFeet(double feet) => new(feet * 12.0);
+    public static Length FromFeet(double feet)
+    {
+        ValidateFiniteNonNegative(feet, nameof(feet), "Feet");
+        return new(feet * InchesPerFoot);
+    }
 
     /// <summary>
     /// Creates a <see cref="Length"/> from a feet + inches pair.
@@ -47,16 +54,26 @@ public readonly record struct Length
     /// <param name="inches">Inches portion (must be finite and non-negative).</param>
     public static Length FromFeetAndInches(double feet, double inches)
     {
-        if (double.IsNaN(feet) || double.IsInfinity(feet))
-            throw new ArgumentOutOfRangeException(nameof(feet), "Feet must be a finite number.");
-        if (double.IsNaN(inches) || double.IsInfinity(inches))
-            throw new ArgumentOutOfRangeException(nameof(inches), "Inches must be a finite number.");
-        if (feet < 0)
-            throw new ArgumentOutOfRangeException(nameof(feet), "Feet cannot be negative.");
-        if (inches < 0)
-            throw new ArgumentOutOfRangeException(nameof(inches), "Inches cannot be negative.");
+        ValidateFiniteNonNegative(feet, nameof(feet), "Feet");
+        ValidateFiniteNonNegative(inches, nameof(inches), "Inches");
+        return new Length((feet * InchesPerFoot) + inches);
+    }
 
-        return new Length((feet * 12.0) + inches);
+    /// <summary>
+    /// Creates a <see cref="Length"/> from a value in the given unit basis.
+    /// </summary>
+    public static Length From(double value, UnitBasis basis)
+    {
+        ValidateFiniteNonNegative(value, nameof(value), "Value");
+        return basis switch
+        {
+            UnitBasis.Inches => FromInches(value),
+            UnitBasis.Feet => FromFeet(value),
+            UnitBasis.Millimeters => FromInches(value / MillimetersPerInch),
+            UnitBasis.Centimeters => FromInches((value * 10.0) / MillimetersPerInch),
+            UnitBasis.Meters => FromInches((value * 1000.0) / MillimetersPerInch),
+            _ => throw new ArgumentOutOfRangeException(nameof(basis), basis, "Unsupported unit basis.")
+        };
     }
 
     /// <summary>
@@ -90,11 +107,372 @@ public readonly record struct Length
     }
 
     /// <summary>
+    /// Converts this length to the requested unit basis.
+    /// </summary>
+    public double To(UnitBasis basis)
+    {
+        return basis switch
+        {
+            UnitBasis.Inches => TotalInches,
+            UnitBasis.Feet => TotalFeet,
+            UnitBasis.Millimeters => TotalInches * MillimetersPerInch,
+            UnitBasis.Centimeters => (TotalInches * MillimetersPerInch) / 10.0,
+            UnitBasis.Meters => (TotalInches * MillimetersPerInch) / 1000.0,
+            _ => throw new ArgumentOutOfRangeException(nameof(basis), basis, "Unsupported unit basis.")
+        };
+    }
+
+    /// <summary>
+    /// Formats the length in the requested style and basis.
+    /// </summary>
+    public string Format(UnitStyle style, UnitBasis basis = UnitBasis.Inches, int precision = 3)
+    {
+        if (precision < 0)
+            throw new ArgumentOutOfRangeException(nameof(precision), "Precision cannot be negative.");
+
+        return style switch
+        {
+            UnitStyle.Architectural => FormatArchitectural(),
+            UnitStyle.Engineering => FormatEngineering(precision),
+            UnitStyle.Decimal => $"{FormatDecimal(To(basis), precision)} {GetUnitSuffix(basis)}",
+            UnitStyle.Scientific => $"{Math.Round(To(basis), precision, MidpointRounding.AwayFromZero).ToString($"E{precision}", System.Globalization.CultureInfo.InvariantCulture)} {GetUnitSuffix(basis)}",
+            _ => throw new ArgumentOutOfRangeException(nameof(style), style, "Unsupported unit style.")
+        };
+    }
+
+    /// <summary>
+    /// Parses a length from a supported string format.
+    /// </summary>
+    public static Length Parse(string text)
+    {
+        if (!TryParse(text, out var length))
+            throw new FormatException($"Unable to parse length '{text}'.");
+        return length;
+    }
+
+    /// <summary>
+    /// Tries to parse a length from common construction formats.
+    /// </summary>
+    public static bool TryParse(string? text, out Length length)
+    {
+        length = default;
+
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        var input = text.Trim();
+        if (input.StartsWith("-", StringComparison.Ordinal))
+            return false;
+
+        if (TryParseFeetAndInchesWords(input, out var feet, out var inches))
+        {
+            length = FromInches((feet * InchesPerFoot) + inches);
+            return true;
+        }
+
+        if (TryParseArchitectural(input, out length))
+            return true;
+
+        if ((input.Contains('"') || input.Contains('/')) && TryParseInchesComponent(input, out var inchOnly))
+        {
+            length = FromInches(RoundToNearestArchitecturalFraction(inchOnly));
+            return true;
+        }
+
+        if (TryParseValueWithUnit(input, out var value, out var basis))
+        {
+            length = From(value, basis);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns a human-friendly representation in feet and inches.
     /// </summary>
     public override string ToString()
     {
         // Keep it simple and non-rounding-opinionated for now.
         return $"{TotalFeet:0.###} ft ({TotalInches:0.###} in)";
+    }
+
+    private string FormatArchitectural()
+    {
+        var sixteenths = (int)Math.Round(TotalInches * ArchitecturalDenominator, 0, MidpointRounding.AwayFromZero);
+        var sixteenthsPerFoot = InchesPerFoot * ArchitecturalDenominator;
+        var feet = sixteenths / sixteenthsPerFoot;
+        var remainder = sixteenths % sixteenthsPerFoot;
+        var wholeInches = remainder / ArchitecturalDenominator;
+        var fraction = remainder % ArchitecturalDenominator;
+
+        if (fraction == 0)
+            return $"{feet}'-{wholeInches}\"";
+
+        var divisor = Gcd(fraction, ArchitecturalDenominator);
+        var numerator = fraction / divisor;
+        var denominator = ArchitecturalDenominator / divisor;
+
+        if (wholeInches == 0)
+            return $"{feet}'-{numerator}/{denominator}\"";
+
+        return $"{feet}'-{wholeInches} {numerator}/{denominator}\"";
+    }
+
+    private string FormatEngineering(int precision)
+    {
+        var feet = (int)Math.Floor(TotalInches / InchesPerFoot);
+        var inches = TotalInches - (feet * InchesPerFoot);
+        var roundedInches = Math.Round(inches, precision, MidpointRounding.AwayFromZero);
+
+        if (roundedInches >= InchesPerFoot)
+        {
+            feet += (int)Math.Floor(roundedInches / InchesPerFoot);
+            roundedInches %= InchesPerFoot;
+        }
+
+        return $"{feet}'-{FormatDecimal(roundedInches, precision)}\"";
+    }
+
+    private static bool TryParseArchitectural(string input, out Length length)
+    {
+        length = default;
+
+        var quoteIndex = input.IndexOf('\'');
+        if (quoteIndex < 0)
+            return false;
+
+        var feetPart = input[..quoteIndex].Trim();
+        if (feetPart.StartsWith("+", StringComparison.Ordinal))
+            feetPart = feetPart[1..].Trim();
+
+        if (!TryParseNonNegativeNumber(feetPart, out var feet))
+            return false;
+
+        var remainder = input[(quoteIndex + 1)..].TrimStart();
+        remainder = remainder.TrimStart('-', ' ');
+
+        if (string.IsNullOrWhiteSpace(remainder))
+        {
+            length = FromFeet(feet);
+            return true;
+        }
+
+        if (!TryParseInchesComponent(remainder, out var inches))
+            return false;
+
+        var normalizedInches = RoundToNearestArchitecturalFraction((feet * InchesPerFoot) + inches);
+        length = FromInches(normalizedInches);
+        return true;
+    }
+
+    private static bool TryParseFeetAndInchesWords(string input, out double feet, out double inches)
+    {
+        feet = 0;
+        inches = 0;
+
+        var tokens = input.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (tokens.Length < 2 || tokens.Length > 4)
+            return false;
+
+        var feetToken = tokens[0];
+        var feetUnit = tokens[1].ToLowerInvariant();
+        if (feetUnit is not ("ft" or "foot" or "feet"))
+            return false;
+
+        if (!TryParseNonNegativeNumber(feetToken.TrimStart('+'), out feet))
+            return false;
+
+        if (tokens.Length == 2)
+            return true;
+
+        var inchesToken = tokens[2];
+        if (!TryParseNonNegativeNumber(inchesToken, out inches))
+            return false;
+
+        if (tokens.Length == 3)
+            return true;
+
+        var inchUnit = tokens[3].ToLowerInvariant();
+        return inchUnit is "in" or "inch" or "inches";
+    }
+
+    private static bool TryParseInchesComponent(string input, out double inches)
+    {
+        inches = 0;
+        var normalized = input.Trim();
+        if (normalized.Length == 0)
+            return false;
+
+        if (normalized.EndsWith("\"", StringComparison.Ordinal))
+            normalized = normalized[..^1].TrimEnd();
+
+        normalized = TrimWordSuffix(normalized, "inches");
+        normalized = TrimWordSuffix(normalized, "inch");
+        normalized = TrimWordSuffix(normalized, "in");
+        normalized = normalized.Trim();
+
+        if (normalized.Length == 0)
+            return false;
+
+        var parts = normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length > 2)
+            return false;
+
+        if (parts.Length == 1)
+        {
+            return TryParseNumberOrFraction(parts[0], out inches);
+        }
+
+        if (!TryParseNonNegativeNumber(parts[0], out var whole))
+            return false;
+        if (!TryParseFraction(parts[1], out var fraction))
+            return false;
+
+        inches = whole + fraction;
+        return true;
+    }
+
+    private static bool TryParseNumberOrFraction(string token, out double value)
+    {
+        if (TryParseNonNegativeNumber(token, out value))
+            return true;
+        return TryParseFraction(token, out value);
+    }
+
+    private static bool TryParseFraction(string token, out double value)
+    {
+        value = 0;
+        var split = token.Split('/', StringSplitOptions.TrimEntries);
+        if (split.Length != 2)
+            return false;
+        if (!int.TryParse(split[0], out var numerator) || numerator < 0)
+            return false;
+        if (!int.TryParse(split[1], out var denominator) || denominator <= 0)
+            return false;
+
+        value = (double)numerator / denominator;
+        return true;
+    }
+
+    private static bool TryParseValueWithUnit(string input, out double value, out UnitBasis basis)
+    {
+        value = 0;
+        basis = UnitBasis.Inches;
+
+        var parts = input.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length is < 1 or > 2)
+            return false;
+
+        var valueToken = parts[0];
+        if (valueToken.StartsWith("+", StringComparison.Ordinal))
+            valueToken = valueToken[1..];
+
+        if (!double.TryParse(
+            valueToken,
+            System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out value))
+        {
+            return false;
+        }
+
+        if (value < 0 || double.IsNaN(value) || double.IsInfinity(value))
+            return false;
+
+        if (parts.Length == 1)
+        {
+            basis = UnitBasis.Inches;
+            return true;
+        }
+
+        var unit = parts[1].ToLowerInvariant();
+        return TryMapUnitBasis(unit, out basis);
+    }
+
+    private static bool TryMapUnitBasis(string unit, out UnitBasis basis)
+    {
+        basis = unit switch
+        {
+            "in" or "inch" or "inches" => UnitBasis.Inches,
+            "ft" or "foot" or "feet" => UnitBasis.Feet,
+            "mm" or "millimeter" or "millimeters" => UnitBasis.Millimeters,
+            "cm" or "centimeter" or "centimeters" => UnitBasis.Centimeters,
+            "m" or "meter" or "meters" => UnitBasis.Meters,
+            _ => UnitBasis.Inches
+        };
+
+        return unit is
+            "in" or "inch" or "inches" or
+            "ft" or "foot" or "feet" or
+            "mm" or "millimeter" or "millimeters" or
+            "cm" or "centimeter" or "centimeters" or
+            "m" or "meter" or "meters";
+    }
+
+    private static string GetUnitSuffix(UnitBasis basis)
+    {
+        return basis switch
+        {
+            UnitBasis.Inches => "in",
+            UnitBasis.Feet => "ft",
+            UnitBasis.Millimeters => "mm",
+            UnitBasis.Centimeters => "cm",
+            UnitBasis.Meters => "m",
+            _ => throw new ArgumentOutOfRangeException(nameof(basis), basis, "Unsupported unit basis.")
+        };
+    }
+
+    private static string FormatDecimal(double value, int precision)
+    {
+        var rounded = Math.Round(value, precision, MidpointRounding.AwayFromZero);
+        var format = precision == 0
+            ? "0"
+            : $"0.{new string('#', precision)}";
+        return rounded.ToString(format, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static int Gcd(int a, int b)
+    {
+        while (b != 0)
+        {
+            var temp = a % b;
+            a = b;
+            b = temp;
+        }
+
+        return Math.Abs(a);
+    }
+
+    private static double RoundToNearestArchitecturalFraction(double totalInches)
+    {
+        return Math.Round(totalInches * ArchitecturalDenominator, 0, MidpointRounding.AwayFromZero) / ArchitecturalDenominator;
+    }
+
+    private static string TrimWordSuffix(string value, string suffix)
+    {
+        if (value.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            return value[..^suffix.Length].TrimEnd();
+        return value;
+    }
+
+    private static bool TryParseNonNegativeNumber(string token, out double value)
+    {
+        var ok = double.TryParse(
+            token,
+            System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out value);
+        if (!ok)
+            return false;
+        return value >= 0 && !double.IsNaN(value) && !double.IsInfinity(value);
+    }
+
+    private static void ValidateFiniteNonNegative(double value, string paramName, string label)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+            throw new ArgumentOutOfRangeException(paramName, $"{label} must be a finite number.");
+        if (value < 0)
+            throw new ArgumentOutOfRangeException(paramName, $"{label} cannot be negative.");
     }
 }

--- a/src/RapidTakeoff.Core/units/UnitBasis.cs
+++ b/src/RapidTakeoff.Core/units/UnitBasis.cs
@@ -1,0 +1,28 @@
+namespace RapidTakeoff.Core.Units;
+
+/// <summary>
+/// Unit basis used for conversion and non-architectural formatting.
+/// </summary>
+public enum UnitBasis
+{
+    /// <summary>
+    /// Inches.
+    /// </summary>
+    Inches,
+    /// <summary>
+    /// Feet.
+    /// </summary>
+    Feet,
+    /// <summary>
+    /// Millimeters.
+    /// </summary>
+    Millimeters,
+    /// <summary>
+    /// Centimeters.
+    /// </summary>
+    Centimeters,
+    /// <summary>
+    /// Meters.
+    /// </summary>
+    Meters
+}

--- a/src/RapidTakeoff.Core/units/UnitStyle.cs
+++ b/src/RapidTakeoff.Core/units/UnitStyle.cs
@@ -1,0 +1,24 @@
+namespace RapidTakeoff.Core.Units;
+
+/// <summary>
+/// Controls how a <see cref="Length"/> is formatted.
+/// </summary>
+public enum UnitStyle
+{
+    /// <summary>
+    /// Feet-inches with fractional inches (nearest 1/16").
+    /// </summary>
+    Architectural,
+    /// <summary>
+    /// Feet-inches with decimal inches.
+    /// </summary>
+    Engineering,
+    /// <summary>
+    /// Decimal value in the selected basis.
+    /// </summary>
+    Decimal,
+    /// <summary>
+    /// Scientific notation in the selected basis.
+    /// </summary>
+    Scientific
+}

--- a/src/RapidTakeoff.Rendering/RapidTakeoff.Rendering.csproj
+++ b/src/RapidTakeoff.Rendering/RapidTakeoff.Rendering.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\RapidTakeoff.Core\RapidTakeoff.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/RapidTakeoff.Rendering/WallStrips/WallStripSvgRenderer.cs
+++ b/src/RapidTakeoff.Rendering/WallStrips/WallStripSvgRenderer.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using RapidTakeoff.Core.Units;
 using RapidTakeoff.Rendering.Walls;
 
 namespace RapidTakeoff.Rendering.WallStrips;
@@ -233,13 +234,16 @@ public sealed class WallStripSvgRenderer
                 }
             }
 
+            var heightDimText = Length.FromFeet(dto.HeightFeet).Format(UnitStyle.Architectural);
+            var lengthDimText = Length.FromFeet(wall.LengthFeet).Format(UnitStyle.Architectural);
+
             // Height dimension marker and label.
             var dimX = rectRight + 22;
             sb.AppendLine($@"  <line x1=""{dimX}"" y1=""{yCursor}"" x2=""{dimX}"" y2=""{rectBottom}"" stroke=""#374151"" stroke-width=""1"" />");
             sb.AppendLine($@"  <line x1=""{dimX - 5}"" y1=""{yCursor}"" x2=""{dimX + 5}"" y2=""{yCursor}"" stroke=""#374151"" stroke-width=""1"" />");
             sb.AppendLine($@"  <line x1=""{dimX - 5}"" y1=""{rectBottom}"" x2=""{dimX + 5}"" y2=""{rectBottom}"" stroke=""#374151"" stroke-width=""1"" />");
             sb.AppendLine(
-                $@"  <text x=""{dimX + 10}"" y=""{yCursor + (stripHeight / 2) + 4}"" font-family=""Arial"" font-size=""11"" text-anchor=""start"">{dto.HeightFeet:F2} ft H</text>");
+                $@"  <text x=""{dimX + 10}"" y=""{yCursor + (stripHeight / 2) + 4}"" font-family=""Arial"" font-size=""11"" text-anchor=""start"">{heightDimText} H</text>");
 
             // Length dimension marker and label along the bottom side.
             var dimY = rectBottom + 18;
@@ -247,7 +251,7 @@ public sealed class WallStripSvgRenderer
             sb.AppendLine($@"  <line x1=""{xCursor}"" y1=""{dimY - 5}"" x2=""{xCursor}"" y2=""{dimY + 5}"" stroke=""#374151"" stroke-width=""1"" />");
             sb.AppendLine($@"  <line x1=""{rectRight:F2}"" y1=""{dimY - 5}"" x2=""{rectRight:F2}"" y2=""{dimY + 5}"" stroke=""#374151"" stroke-width=""1"" />");
             sb.AppendLine(
-                $@"  <text x=""{xCursor + (rectWidth / 2):F2}"" y=""{dimY + 16}"" font-family=""Arial"" font-size=""12"" text-anchor=""middle"">{wall.LengthFeet:F2} ft L</text>");
+                $@"  <text x=""{xCursor + (rectWidth / 2):F2}"" y=""{dimY + 16}"" font-family=""Arial"" font-size=""12"" text-anchor=""middle"">{lengthDimText} L</text>");
 
             // Wall title under each elevation.
             sb.AppendLine(

--- a/tests/RapidTakeoff.Core.Tests/units/LengthTests.cs
+++ b/tests/RapidTakeoff.Core.Tests/units/LengthTests.cs
@@ -26,6 +26,30 @@ public sealed class LengthTests
         Assert.Equal(2.5, len.TotalFeet, 10);
     }
 
+    [Theory]
+    [InlineData(UnitBasis.Inches, 24.0)]
+    [InlineData(UnitBasis.Feet, 2.0)]
+    [InlineData(UnitBasis.Millimeters, 609.6)]
+    [InlineData(UnitBasis.Centimeters, 60.96)]
+    [InlineData(UnitBasis.Meters, 0.6096)]
+    public void To_ConvertsToRequestedBasis(UnitBasis basis, double expected)
+    {
+        var len = Length.FromInches(24);
+        Assert.Equal(expected, len.To(basis), 10);
+    }
+
+    [Theory]
+    [InlineData(UnitBasis.Inches, 24.0)]
+    [InlineData(UnitBasis.Feet, 2.0)]
+    [InlineData(UnitBasis.Millimeters, 609.6)]
+    [InlineData(UnitBasis.Centimeters, 60.96)]
+    [InlineData(UnitBasis.Meters, 0.6096)]
+    public void From_ConvertsFromRequestedBasis(UnitBasis basis, double input)
+    {
+        var len = Length.From(input, basis);
+        Assert.Equal(24.0, len.TotalInches, 10);
+    }
+
     [Fact]
     public void Addition_AddsInches()
     {
@@ -60,10 +84,121 @@ public sealed class LengthTests
         Assert.Throws<ArgumentOutOfRangeException>(() => _ = Length.FromInches(value));
     }
 
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void FromFeet_RejectsInvalid(double value)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = Length.FromFeet(value));
+    }
+
+    [Theory]
+    [InlineData(-0.01, 0)]
+    [InlineData(0, -0.01)]
+    [InlineData(double.NaN, 0)]
+    [InlineData(0, double.NaN)]
+    [InlineData(double.PositiveInfinity, 0)]
+    [InlineData(0, double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity, 0)]
+    [InlineData(0, double.NegativeInfinity)]
+    public void FromFeetAndInches_RejectsInvalid(double feet, double inches)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = Length.FromFeetAndInches(feet, inches));
+    }
+
+    [Theory]
+    [InlineData(UnitBasis.Inches, -0.01)]
+    [InlineData(UnitBasis.Feet, -0.01)]
+    [InlineData(UnitBasis.Millimeters, -0.01)]
+    [InlineData(UnitBasis.Centimeters, -0.01)]
+    [InlineData(UnitBasis.Meters, -0.01)]
+    [InlineData(UnitBasis.Inches, double.NaN)]
+    [InlineData(UnitBasis.Feet, double.PositiveInfinity)]
+    [InlineData(UnitBasis.Millimeters, double.NegativeInfinity)]
+    public void From_WithBasis_RejectsInvalid(UnitBasis basis, double value)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = Length.From(value, basis));
+    }
+
     [Fact]
     public void Division_ByZeroThrows()
     {
         var a = Length.FromInches(10);
         Assert.Throws<DivideByZeroException>(() => _ = a / 0);
+    }
+
+    [Theory]
+    [InlineData(1.0 / 32.0, "0'-1/16\"")]
+    [InlineData(5.5, "0'-5 1/2\"")]
+    [InlineData(11.999, "1'-0\"")]
+    [InlineData(12.0, "1'-0\"")]
+    [InlineData(66.25, "5'-6 1/4\"")]
+    public void Format_Architectural_RoundsCarriesAndReduces(double inches, string expected)
+    {
+        var len = Length.FromInches(inches);
+        Assert.Equal(expected, len.Format(UnitStyle.Architectural));
+    }
+
+    [Theory]
+    [InlineData(11.999, 2, "1'-0\"")]
+    [InlineData(66.25, 2, "5'-6.25\"")]
+    [InlineData(66.2, 0, "5'-6\"")]
+    public void Format_Engineering_RoundsAndCarries(double inches, int precision, string expected)
+    {
+        var len = Length.FromInches(inches);
+        Assert.Equal(expected, len.Format(UnitStyle.Engineering, precision: precision));
+    }
+
+    [Fact]
+    public void Format_Decimal_UsesRequestedBasis()
+    {
+        var len = Length.FromInches(12);
+        Assert.Equal("304.8 mm", len.Format(UnitStyle.Decimal, UnitBasis.Millimeters, precision: 3));
+    }
+
+    [Fact]
+    public void Format_Scientific_UsesRequestedBasis()
+    {
+        var len = Length.FromInches(12);
+        Assert.Equal("3.048E+002 mm", len.Format(UnitStyle.Scientific, UnitBasis.Millimeters, precision: 3));
+    }
+
+    [Theory]
+    [InlineData("5' 6 1/4\"", 66.25)]
+    [InlineData("5'-6 1/4\"", 66.25)]
+    [InlineData("5'", 60.0)]
+    [InlineData("66.25 in", 66.25)]
+    [InlineData("5.5208333333 ft", 66.25)]
+    [InlineData("1682.75 mm", 66.25)]
+    [InlineData("168.275 cm", 66.25)]
+    [InlineData("1.68275 m", 66.25)]
+    [InlineData("5 ft 6.25 in", 66.25)]
+    [InlineData("66.25", 66.25)]
+    [InlineData("1/3\"", 0.3125)] // parse normalization to nearest 1/16
+    public void Parse_ParsesSupportedFormats(string input, double expectedInches)
+    {
+        var len = Length.Parse(input);
+        Assert.Equal(expectedInches, len.TotalInches, 8);
+    }
+
+    [Fact]
+    public void TryParse_ReturnsFalseForUnsupportedInput()
+    {
+        Assert.False(Length.TryParse("abc", out _));
+    }
+
+    [Theory]
+    [InlineData("-1 in")]
+    [InlineData("-1'")]
+    [InlineData("1/-2\"")]
+    [InlineData("1/0\"")]
+    [InlineData("1 parsec")]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Parse_InvalidInputs_ThrowFormatException(string input)
+    {
+        Assert.Throws<FormatException>(() => _ = Length.Parse(input));
     }
 }

--- a/tests/RapidTakeoff.Rendering.Tests/WallStripSvgRendererTests.cs
+++ b/tests/RapidTakeoff.Rendering.Tests/WallStripSvgRendererTests.cs
@@ -45,8 +45,8 @@ public class WallStripSvgRendererTests
 
         Assert.Contains("<rect", svg);
         Assert.Contains("Wall 1", svg);
-        Assert.Contains("8.00 ft H", svg);
-        Assert.Contains("12.00 ft L", svg);
+        Assert.Contains("8'-0\" H", svg);
+        Assert.Contains("12'-0\" L", svg);
         Assert.Contains("Summary", svg);
         Assert.Contains("Assumptions", svg);
         Assert.Contains("Stud spacing: 16 in on-center.", svg);

--- a/tickets/2026-03-01-units-rounding/brief.md
+++ b/tickets/2026-03-01-units-rounding/brief.md
@@ -1,0 +1,11 @@
+# Brief — Units & Rounding Policy
+
+- Canonical length type is `RapidTakeoff.Core.Units.Length` storing inches in `TotalInches`.
+- Enforce invariants everywhere: finite and non-negative (no negatives allowed).
+- Add formatting + parsing as the single source of truth for construction units:
+  - Architectural feet–inches–fractions, rounded to nearest 1/16".
+  - Engineering feet + decimal inches.
+  - Decimal and Scientific output in in/ft/mm/cm/m.
+- All rounding must use MidpointRounding.AwayFromZero and occur only at formatting (and parse normalization).
+- Add unit tests for invariants, conversions, formatting (incl carry/reduce), parsing, and invalid inputs.
+- Keep scope minimal: do not refactor all project/input models or serialization.

--- a/tickets/2026-03-01-units-rounding/review.md
+++ b/tickets/2026-03-01-units-rounding/review.md
@@ -1,0 +1,20 @@
+# Review Notes
+
+## Spec compliance
+- [ ] Invariants enforced everywhere (constructor + factories)
+- [ ] Architectural formatting: 1/16 rounding + carry + fraction reduction
+- [ ] Engineering formatting: carry inches overflow
+- [ ] Decimal/scientific formatting ok
+- [ ] Parsing covers required patterns and rejects negatives
+- [ ] All rounding AwayFromZero
+
+## Tests
+- [ ] Invariant tests
+- [ ] Conversion tests
+- [ ] Formatting tests (arch + eng)
+- [ ] Parsing tests
+- [ ] Invalid input tests
+
+## Follow-ups (new tickets)
+- [ ] Boundary normalization (Project/ProjectPenetration)
+- [ ] Replace raw doubles in input models

--- a/tickets/2026-03-01-units-rounding/spec.md
+++ b/tickets/2026-03-01-units-rounding/spec.md
@@ -1,0 +1,339 @@
+# Ticket: Units & Rounding Policy (Length)
+
+## 1. Goal
+Establish a single, consistent units/rounding policy for `RapidTakeoff.Core.Units.Length` (canonical inches) and provide robust formatting + parsing for common construction unit styles. Enforce invariants (finite, non-negative) so negative lengths cannot be constructed or parsed. Architectural output must round to the nearest 1/16".
+
+## 2. Non-Goals
+- Do NOT refactor all project/input models (e.g., `Project`, `ProjectPenetration`) to use `Length` end-to-end in this ticket.
+- Do NOT change serialization formats or JSON schemas.
+- Do NOT add new CLI commands/flags unrelated to length parsing/formatting.
+- Do NOT introduce a database, server, or website changes.
+- Do NOT add rounding logic outside of `RapidTakeoff.Core.Units` (except tests).
+
+## 3. Current State (as observed)
+- Canonical type exists: `public readonly record struct Length`
+- Canonical storage: `public double TotalInches { get; }`
+- Convenience: `public double TotalFeet => TotalInches / 12.0;`
+- Factories:
+  - `FromInches(double inches) => new(inches);` (no validation today)
+  - `FromFeet(double feet) => new(feet * 12.0);` (no validation today)
+  - `FromFeetAndInches(double feet, double inches)` validates finite + non-negative
+
+## 4. Requirements
+
+### 4.1 Invariants (must be enforced everywhere)
+A `Length` must always be:
+- Finite (`!NaN`, `!Infinity`)
+- Non-negative (`>= 0`)
+
+#### 4.1.1 Constructor enforcement
+Add an explicit constructor to `Length` so `new Length(x)` cannot bypass invariants.
+
+Required behavior:
+- If `totalInches` is NaN or Infinity: throw `ArgumentOutOfRangeException`
+- If `totalInches < 0`: throw `ArgumentOutOfRangeException`
+
+#### 4.1.2 Factory method enforcement
+Update factories to enforce invariants:
+- `FromInches(double inches)` validates finite + non-negative
+- `FromFeet(double feet)` validates finite + non-negative before conversion
+- `FromFeetAndInches(...)` already validates; keep it, but ensure it routes through the invariant constructor (directly or indirectly)
+
+### 4.2 Unit Styles and Bases (enums)
+Add enums under `RapidTakeoff.Core.Units` namespace:
+
+```csharp
+public enum UnitStyle
+{
+    Architectural, // feet-inches-fractional inches
+    Engineering,   // feet + decimal inches
+    Decimal,       // decimal in chosen basis (in/ft/mm/cm/m)
+    Scientific     // scientific notation in chosen basis
+}
+
+public enum UnitBasis
+{
+    Inches,
+    Feet,
+    Millimeters,
+    Centimeters,
+    Meters
+}
+
+4.3 Conversions (exhaustive/common)
+
+Add conversion support for all UnitBasis values.
+
+Required:
+
+12 inches = 1 foot
+
+1 inch = 25.4 mm (exact)
+
+cm/m via mm
+
+Conversions must reject negative/NaN/Infinity at input boundaries (via Length invariants)
+
+Required API additions:
+
+public double To(UnitBasis basis);
+
+public static Length From(UnitBasis basis, double value);
+4.4 Rounding Policy (single source of truth)
+
+All rounding relevant to Length must use:
+
+MidpointRounding.AwayFromZero
+
+Rounding must happen ONLY at formatting boundaries (and parse normalization where appropriate), not during intermediate calculations.
+
+4.5 Formatting APIs
+
+Add formatting methods to Length:
+
+public string ToArchitecturalString(int denom = 16);
+
+public string ToEngineeringString(int decimalInches = 2);
+
+public string ToDecimalString(
+    UnitBasis basis = UnitBasis.Inches,
+    int decimals = 2,
+    bool includeUnitSuffix = true
+);
+
+public string ToScientificString(
+    UnitBasis basis = UnitBasis.Inches,
+    int significantDigits = 6,
+    bool includeUnitSuffix = true
+);
+
+// Router convenience (optional but recommended)
+public string Format(
+    UnitStyle style = UnitStyle.Architectural,
+    UnitBasis basis = UnitBasis.Inches,
+    int precision = 2,
+    int denom = 16,
+    int significantDigits = 6,
+    bool includeUnitSuffix = true
+);
+4.5.1 Architectural formatting rules
+
+Output format: F'-I N/D" or F'-I" or F'-0"
+
+Always include feet and inches.
+
+Example: 10'-3 1/2", 10'-3", 10'-0"
+
+Rounding: nearest 1/denom inch. Default denom = 16.
+
+Normalize/carry:
+
+If fraction rounds to denom/denom, increment inches and clear fraction.
+
+If inches becomes 12, increment feet and set inches to 0.
+
+Reduce fractions:
+
+e.g. 8/16 -> 1/2, 2/16 -> 1/8
+
+No negative sign ever appears.
+
+4.5.2 Engineering formatting rules (feet + decimal inches)
+
+Output format: F'-I.DD"
+
+Feet is integer.
+
+Inches is decimal with decimalInches places (default 2).
+
+Inches must be normalized to [0, 12), carrying into feet as needed.
+
+Rounding: AwayFromZero at decimalInches.
+
+4.5.3 Decimal formatting rules
+
+Output: <value> <unit>
+
+Examples: 123.50 in, 10.29 ft, 3136.90 mm
+
+Rounding: AwayFromZero at decimals
+
+Unit suffixes:
+
+in, ft, mm, cm, m
+
+4.5.4 Scientific formatting rules
+
+Output: <value> <unit> where value is in scientific notation
+
+Example: 1.234567E+02 in
+
+Significant digits: default 6
+
+Unit suffixes as above
+
+4.6 Parsing APIs
+
+Add:
+
+public static bool TryParse(string input, out Length length, out string? error);
+
+public static Length Parse(string input);
+
+Parsing must:
+
+Reject negatives anywhere.
+
+Be whitespace tolerant.
+
+Be case-insensitive for unit suffixes.
+
+4.6.1 Supported input forms (v0)
+
+Architectural-ish:
+
+10'-3 1/2"
+
+10' 3 1/2"
+
+10'3-1/2"
+
+3 1/2"
+
+7/16"
+
+4" / 4 in
+
+Engineering-ish:
+
+10'-3.25"
+
+3.25" / 3.25 in
+
+Decimal with units:
+
+10.5 ft
+
+120 in
+
+300 mm
+
+30 cm
+
+3 m
+
+If the input has no explicit unit:
+
+If it contains ' or " or /, parse as architectural/engineering feet/inches.
+
+Otherwise parse as decimal inches.
+
+4.7 Error handling
+
+TryParse returns false and sets error to a helpful message.
+
+Parse throws FormatException with a helpful message.
+
+5. Test Matrix (must add)
+5.1 Invariants
+
+new Length(-1) throws ArgumentOutOfRangeException
+
+Length.FromInches(-0.01) throws
+
+Length.FromFeet(-0.01) throws
+
+Length.Parse("-1\"") throws (or TryParse false)
+
+5.2 Conversions
+
+Length.FromInches(1).To(UnitBasis.Millimeters) == 25.4 (tolerance)
+
+Length.FromFeet(1).TotalInches == 12.0
+
+Round-trip sanity checks for a few values.
+
+5.3 Architectural formatting (1/16")
+
+Length.FromInches(123.5) => 10'-3 1/2"
+
+Length.FromInches(120) => 10'-0"
+
+Length.FromInches(0.03125) (1/32) rounds to 0'-0" at denom=16
+
+Carry case:
+
+a value that rounds to ... 12" must carry to next foot correctly (add at least one explicit test)
+
+5.4 Engineering formatting
+
+Length.FromInches(123.5).ToEngineeringString(2) => 10'-3.50"
+
+A value whose inches part rounds to 12.00 must carry to feet.
+
+5.5 Parsing
+
+Add tests that each supported input parses to expected TotalInches (within tolerance):
+
+10'-3 1/2"
+
+10' 3 1/2"
+
+10'3-1/2"
+
+3 1/2"
+
+7/16"
+
+4"
+
+10'-3.25"
+
+10.5 ft
+
+300 mm
+
+Also add at least 3 invalid inputs:
+
+negative
+
+nonsense string
+
+malformed fraction (e.g. 3/0")
+
+6. Definition of Done
+
+dotnet test passes
+
+All new rounding uses MidpointRounding.AwayFromZero
+
+Length invariants cannot be bypassed via new Length(...) or factories
+
+Formatting/parsing covered by the test matrix
+
+Add documentation file: docs/units-rounding.md summarizing:
+
+canonical storage (inches)
+
+supported formats
+
+rounding rules
+
+examples
+
+
+---
+
+## Suggested `brief.md` (optional, but nice)
+If you want the folder to be complete, here’s a short `brief.md` you can drop in too:
+
+```markdown
+# Brief
+Canonical length unit is inches (`RapidTakeoff.Core.Units.Length`). Negative lengths must be impossible to construct or parse. Add robust parsing and formatting for construction styles:
+
+- Architectural: feet-inches-fractions rounded to 1/16"
+- Engineering: feet + decimal inches
+- Decimal: decimal value in in/ft/mm/cm/m
+- Scientific: scientific notation in in/ft/mm/cm/m
+
+All rounding must be MidpointRounding.AwayFromZero. Add exhaustive tests for rounding/carry and parsing edge cases.


### PR DESCRIPTION
<!--
Optional marker for a first-contact CI run.
Include this only if you are intentionally attempting a Black Flash.

BLACK_FLASH_ATTEMPT
-->

## What changed
Expanded Length into a full unit primitive in src/RapidTakeoff.Core/units/Length.cs:
- Enforced finite/non-negative invariants
- Added unit conversion APIs (From(value, basis), To(basis))
- Added formatting styles (architectural, engineering, decimal, scientific)
- Added parsing (Parse/TryParse) for multiple unit formats
- Architectural rounding policy to nearest 1/16" using AwayFromZero
- Added unit enums:
- src/RapidTakeoff.Core/units/UnitBasis.cs
- src/RapidTakeoff.Core/units/UnitStyle.cs
- Changed SVG dimension defaults to architectural formatting in src/RapidTakeoff.Rendering/WallStrips/WallStripSvgRenderer.cs, and added Core reference in src/RapidTakeoff.Rendering/RapidTakeoff.Rendering.csproj.

Added/updated tests:

- Expanded unit matrix in tests/RapidTakeoff.Core.Tests/units/LengthTests.cs
- Updated renderer expectations in tests/RapidTakeoff.Rendering.Tests/WallStripSvgRendererTests.cs

Added ticket docs:

- tickets/2026-03-01-units-rounding/brief.md
- tickets/2026-03-01-units-rounding/review.md
- tickets/2026-03-01-units-rounding/spec.md

## Preflight
- [x] I ran `.\scripts\preflight.ps1`